### PR TITLE
fix rtd requirements

### DIFF
--- a/doc/rtd_reqs.txt
+++ b/doc/rtd_reqs.txt
@@ -1,9 +1,1 @@
-matplotlib>=1.4
-numpy>=1.10
-scipy>=0.17
-cython>=0.22
-sphinx>=1.4
-numpydoc
-jupyter
-nbsphinx
-coverage
+-e .[doc]


### PR DESCRIPTION
the iDEA package itself was not installed, resulting in the cython
extensions not being built.