### PR TITLE
Fixed normalisation issue in EXT/NON

### DIFF
--- a/iDEA/EXT1.py
+++ b/iDEA/EXT1.py
@@ -218,7 +218,8 @@ def main(parameters):
             # Normalise the wavefunction 
             norm = npla.norm(wavefunction)*np.sqrt(pm.space.delta)
             wavefunction /= norm
-            string = 'EXT: t = {:.5f}, normalisation = {}'.format(i*pm.sys.deltat, norm**2)
+            norm = npla.norm(wavefunction)*np.sqrt(pm.space.delta)
+            string = 'EXT: t = {:.5f}, normalisation = {}'.format(i*pm.sys.deltat, norm)
             pm.sprint(string, 1, newline=False)
 
             # Calculate the density

--- a/iDEA/EXT2.py
+++ b/iDEA/EXT2.py
@@ -572,6 +572,7 @@ def solve_real_time(pm, A_reduced, C_reduced, wavefunction, reduction_matrix, ex
         norm = npla.norm(wavefunction)*pm.space.delta
         if(pm.sys.im == 0):
             wavefunction /= norm
+            norm = npla.norm(wavefunction)*pm.space.delta
             
         # Calculate the density 
         wavefunction_2D = wavefunction.reshape(pm.space.npt, pm.space.npt)
@@ -594,7 +595,7 @@ def solve_real_time(pm, A_reduced, C_reduced, wavefunction, reduction_matrix, ex
                 pm.sprint(string, 1, newline=False, savelog=False)
         else:
             string_one = 'residual: {:.5f}'.format(npla.norm(A_reduced*wavefunction_reduced - b_reduced))
-            string_two = 'normalisation: {:.5f}'.format(norm**2)
+            string_two = 'normalisation: {:.5f}'.format(norm)
             string_three = '--------------------------------------------------------------'
             if(i % 100 == 0):
                 pm.sprint(string_one, 0)

--- a/iDEA/EXT3.py
+++ b/iDEA/EXT3.py
@@ -587,6 +587,7 @@ def solve_real_time(pm, A_reduced, C_reduced, wavefunction, reduction_matrix, ex
         norm = npla.norm(wavefunction)*(np.sqrt(pm.space.delta)**3)
         if(pm.sys.im == 0):
             wavefunction /= norm
+            norm = npla.norm(wavefunction)*(np.sqrt(pm.space.delta)**3)
        
         # Calculate the density 
         wavefunction_3D = wavefunction.reshape(pm.space.npt, pm.space.npt, pm.space.npt)
@@ -609,7 +610,7 @@ def solve_real_time(pm, A_reduced, C_reduced, wavefunction, reduction_matrix, ex
                 pm.sprint(string, 1, newline=False, savelog=False)
         else:
             string_one = 'residual: {:.5f}'.format(npla.norm(A_reduced*wavefunction_reduced - b_reduced))
-            string_two = 'normalisation: {:.5f}'.format(norm**2)
+            string_two = 'normalisation: {:.5f}'.format(norm)
             string_three = '--------------------------------------------------------------'
             if(i % 100 == 0):
                 pm.sprint(string_one, 0)

--- a/iDEA/NON.py
+++ b/iDEA/NON.py
@@ -223,7 +223,8 @@ def main(parameters):
                 # Normalise the wavefunction 
                 norm = npla.norm(wavefunction)*np.sqrt(pm.space.delta)
                 wavefunction /= norm
-                string = 'NON: t = {:.5f}, normalisation = {}'.format(i*pm.sys.deltat, norm**2)
+                norm = npla.norm(wavefunction)*np.sqrt(pm.space.delta)
+                string = 'NON: t = {:.5f}, normalisation = {}'.format(i*pm.sys.deltat, norm)
                 pm.sprint(string, 1, newline=False)
   
                 # Calculate the density


### PR DESCRIPTION
This doesn't affect any results, but the normalisation
being printed to the screen in the real time propagation
is wrong, and therefore misleading. The fix checks that
the wavefunction is correctly normalised at each time
step.