### PR TITLE
fix rtd builds

### DIFF
--- a/doc/rtd_reqs.txt
+++ b/doc/rtd_reqs.txt
@@ -1,1 +1,2 @@
--e .[doc]
+pip>=10
+-e .[doc] --no-build-isolation


### PR DESCRIPTION
rtd build fails because of too old pip version
try to add pip in installation requirements