### PR TITLE
include pyproject.toml in MANIFEST

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
 include MIT
+include pyproject.toml
 recursive-include iDEA *pyx
 recursive-include examples *.ipynb
 recursive-include scripts *.py
-

--- a/README.md
+++ b/README.md
@@ -29,14 +29,19 @@ The quickest way to try out iDEA are the
 [iDEA demos](https://github.com/godby-group/idea-demos), which allow to run iDEA directly in the browser
 using live jupyter notebooks.
 
-In order to install iDEA locally, type:
+### Prerequisites
 
+ * `python >= 3.3`
+ * `pip >= 10`
+
+### Installation
+
+From PYPI:
 ```bash
 pip install --user idea-code
 ```
 
 For development, get the latest version from the git repository:
-
 ```bash
 git clone https://github.com/godby-group/idea-public.git
 cd idea-public

--- a/iDEA/info.py
+++ b/iDEA/info.py
@@ -3,7 +3,7 @@
 # The short X.Y version.
 version = '0.1'
 # The full version, including alpha/beta/rc tags.
-release = '0.1.0a1'
+release = '0.1.0a2'
 
 def get_sha1():
     """Returns sha1 hash of last commit from git


### PR DESCRIPTION
this fixes install on ubuntu, for which we don't offer a pre-built wheel